### PR TITLE
Blender_Playblast_v13.py

### DIFF
--- a/AdvancedBoomsmash_011.py
+++ b/AdvancedBoomsmash_011.py
@@ -1,12 +1,31 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+
 bl_info = {
-    'name': 'Advanced Boomsmash',
-    'author': 'Luciano Muñoz & Cristian Hasbun',
-    'version': (0, 11),
-    'blender': (2, 7, 1),
-    'location': 'View3D > Tools > Animation > Boomsmash',
-    'description': 'Have quick access for opengl previews without the need to change your render settings',
-    'warning': "It's very first beta! The addon is in progress!",
-    'category': 'Animation'}
+    "name": "Blender Playblast",
+    "author": "Luciano Muñoz & Cristian Hasbun & Salvador Garcia",
+    "version": (0, 13),
+    "blender": (2, 79, 0),
+    "location": "View3D > Toolshelf > Playblast",
+    "description": "Preview animation by screen-capturing frames",
+    "warning": "The addon still in progress! Be careful!",
+    "category": "Render"}
 
 import os.path
 
@@ -23,7 +42,7 @@ class BoomProps(bpy.types.PropertyGroup):
 
     global_toggle = BoolProperty(
         name = 'Global',
-        description = 'Same boomsmash settings for all scenes in file.',
+        description = 'Same Playblast settings for all scenes in file.',
         default = False)
 
     #twm.image_settings = bpy.types.ImageFormatSettings(
@@ -35,96 +54,100 @@ class BoomProps(bpy.types.PropertyGroup):
 
     incremental = BoolProperty(
         name = 'Incremental',
-        description = 'Save incremental boomsmashes.',
+        description = 'Save incremental Playblast.',
         default = False)
 
     use_stamp = BoolProperty(
         name = 'Stamp',
         description = 'Turn on stamp (uses settings from render properties).',
-        default = False)    
-        
+        default = False)
+
     transparent = BoolProperty(
         name = 'Transparent',
         description = 'Make background transparent (only for formats that support alpha, i.e.: .png).',
         default = False)
-        
+
     autoplay = BoolProperty(
         name = 'Autoplay',
-        description = 'Automatically play boomsmash after making it.',
-        default = False)              
-        
+        description = 'Autoplay after making it.',
+        default = True)
+
     unsimplify = BoolProperty(
-        name = 'Unsimplify',
-        description = "Boomsmash with the subdivision surface levels at it's render settings.",
+        name = 'Simplify Off',
+        description = "Playblast with the Subsurf level at it's render settings.",
         default = False)
-        
+
     onlyrender = BoolProperty(
         name = 'Only Render',
-        description = 'Only have renderable objects visible during boomsmash.',
+        description = 'Only have renderable objects visible during Playblast.',
         default = False)
-        
+
     frame_skip = IntProperty(
         name = 'Skip Frames',
         description = 'Number of frames to skip',
         default = 0,
-        min = 0)        
+        min = 0)
 
     resolution_percentage = IntProperty(
-        name = 'Resolution Percentage',
-        description = 'define a percentage of the Render Resolution to make your boomsmash',
+        subtype = "PERCENTAGE",
+        name = '',
+        description = 'Porcentage scale for render resolution playblast',
         default = 50,
         min = 0,
-        max = 100)        
+        max = 100)
 
     #DEBUG
     #pu.db
 
     dirname = StringProperty(
         name = '',
-        description = 'Folder where your boomsmash will be stored',
-        default = bpy.app.tempdir,
-        subtype = 'DIR_PATH')  
+        description = 'Folder where your Playblast will be stored',
+        #default = bpy.app.tempdir,
+        default = '/tmp/',
+        subtype = 'DIR_PATH')
 
     filename = StringProperty(
+        subtype = 'FILE_NAME',
         name = '',
-        description = 'Filename where your boomsmash will be stored',
-        default = 'Boomsmash',
-        subtype = 'FILE_NAME')  
+        description = 'Filename where your Playblast will be stored',
+        default = 'playblast_')
 
 
 class setDirname(bpy.types.Operator):
     bl_idname = 'bs.setdirname'
-    bl_label = 'BoomsmashDirname'
-    bl_description = 'boomsmash use blendfile directory'
+    bl_label = 'PlayblastDirname'
+    bl_description = 'Use blend file directory'
     bl_options = {'REGISTER', 'INTERNAL'}
-    
+
     def execute(self, context):
         cs = context.scene
-        cs.boom_props.dirname = os.path.dirname(bpy.data.filepath)
-        return {'FINISHED'} 
-            
+        #cs.boom_props.dirname = os.path.dirname(bpy.data.filepath)
+        file_path = os.path.dirname(bpy.data.filepath)
+        cs.boom_props.dirname = file_path + '/'
+        return {'FINISHED'}
+
 
 class setFilename(bpy.types.Operator):
     bl_idname = 'bs.setfilename'
-    bl_label = 'BoomsmashFilename'
-    bl_description = 'boomsmash use blendfile name _ scene name'
+    bl_label = 'PlayblastFilename'
+    bl_description = 'Rename to: file name _ scene name _'
     bl_options = {'REGISTER', 'INTERNAL'}
-    
+
     def execute(self, context):
         cs = context.scene
         blend_name = os.path.basename(
                       os.path.splitext(bpy.data.filepath)[0])
-        cs.boom_props.filename = blend_name + '_' + bpy.context.scene.name
-        return {'FINISHED'} 
-    
+        cs.boom_props.filename = blend_name + '_' + bpy.context.scene.name + '_'
+        return {'FINISHED'}
+
 
 class DoBoom(bpy.types.Operator):
     bl_idname = 'bs.doboom'
-    bl_label = 'Boomsmash'
-    bl_description = 'Start boomsmash, use, enjoy, think about donate ;)'
+    bl_label = 'Playblast'
+    bl_description = 'Preview animation by screen-capturing frames'
     bl_options = {'REGISTER'}
 
-    def execute(self, context): 
+    def execute(self, context):
         cs = context.scene
         wm = context.window_manager
         rd = context.scene.render
@@ -140,7 +163,7 @@ class DoBoom(bpy.types.Operator):
         #guardo settings
         old_use_stamp = rd.use_stamp
         old_onlyrender = sd.show_only_render
-        old_simplify = rd.use_simplify 
+        old_simplify = rd.use_simplify
         old_filepath = rd.filepath
         old_alpha_mode = rd.alpha_mode
         #old_image_settings = rd.image_settings
@@ -161,13 +184,13 @@ class DoBoom(bpy.types.Operator):
         view_pers = context.area.spaces[0].region_3d.view_perspective
         if boom_props.scene_cam and view_pers is not 'CAMERA':
             context.area.spaces[0].region_3d.view_perspective = 'CAMERA'
-           
-        
+
+
         #ejecuto
         bpy.ops.render.opengl(animation = True)
         if boom_props.autoplay:
             bpy.ops.render.play_rendered_anim()
- 
+
         #devuelvo settings
         rd.use_stamp = old_use_stamp
         sd.show_only_render = old_onlyrender
@@ -180,23 +203,28 @@ class DoBoom(bpy.types.Operator):
         if boom_props.scene_cam and view_pers is not 'CAMERA':
             context.area.spaces[0].region_3d.view_perspective = view_pers
 
-        return {'FINISHED'}  
-    
+        return {'FINISHED'}
+
     #def cancel(self, context):
     #    print('cancelado...')
-    #    return {'CANCELLED'}  
+    #    return {'CANCELLED'}
 
 def draw_boomsmash_panel(context, layout):
     col = layout.column(align = True)
     cs = context.scene
-    wm = context.window_manager 
+    wm = context.window_manager
     rd = context.scene.render
 
     if wm.boom_props.global_toggle:
         boom_props = wm.boom_props
     else:
         boom_props = cs.boom_props
-    
+
+    row = col.row()
+    col.operator('bs.doboom', text = 'Playblast', icon = 'RENDER_ANIMATION')
+    col.prop(context.window_manager.boom_props, 'global_toggle')
+    col.separator()
+
     split = col.split()
     subcol = split.column()
     #subcol.prop(boom_props, 'incremental')
@@ -208,49 +236,84 @@ def draw_boomsmash_panel(context, layout):
     subcol.prop(boom_props, 'transparent')
     subcol.prop(boom_props, 'autoplay')
     subcol.prop(boom_props, 'unsimplify')
-    
+
     col.separator()
-    col.label(text = 'Use preview range:')
+    col.label(text = 'Time range:')
     sub = col.split()
     subrow = sub.row(align = True)
     subrow.prop(context.scene, 'use_preview_range', text = '')
     subrow.prop(context.scene, 'frame_preview_start', text = 'Start')
-    subrow.prop(boom_props, 'frame_skip', text = 'Skip')
     subrow.prop(context.scene, 'frame_preview_end', text = 'End')
+    subrow.prop(boom_props, 'frame_skip', text = 'Skip')
     col.separator()
-    
+
     final_res_x = (rd.resolution_x * boom_props.resolution_percentage) / 100
     final_res_y = (rd.resolution_y * boom_props.resolution_percentage) / 100
-    col.label(text = 'Final Resolution: {} x {}'.format(str(final_res_x)[:-2], str(final_res_y)[:-2]))
+    col.label(text = 'Display size: {} x {}'.format(str(final_res_x)[:-2], str(final_res_y)[:-2]))
     col.prop(boom_props, 'resolution_percentage', slider = True )
-    
+
     col.separator()
-    
+
     #col.label(text = 'Output Format:')
     #col.template_image_settings(wm.image_settings, color_management = False)
 
-    col.label(text = 'boomsmash folder:')
+    '''
+    col.label(text = 'Output folder:')
     row = col.row()
     row.prop(cs.boom_props, 'dirname')
-    row.operator('bs.setdirname', text = '', icon = 'FILE_FOLDER')
+    row.operator('bs.setdirname', text = '', icon = 'PACKAGE')
     col.separator()
-    col.label(text = 'boomsmash filename:')
+    col.label(text = 'Movie file:')
     row = col.row()
     row.prop(cs.boom_props, 'filename')
-    row.operator('bs.setfilename', text = '', icon = 'FILE_BLEND')
+    row.operator('bs.setfilename', text = '', icon = 'SCENE_DATA')
+    '''
+
+    image_settings = rd.image_settings
+    file_format = image_settings.file_format
+ 
+    col.label(text = 'Output folder:')
+    row = col.row()
+    row.prop(cs.boom_props, 'dirname')
+    row.operator('bs.setdirname', text = '', icon = 'PACKAGE')
     
+    col.separator()
+    
+    col.label(text = 'Movie file:')
+    row = col.row()
+    row.prop(cs.boom_props, 'filename')
+    row.operator('bs.setfilename', text = '', icon = 'SCENE_DATA')
+ 
+    #split = layout.split()
+ 
+    #col = split.column()
+    
+    col.separator()
+    
+    #col.active = not rd.is_movie_format
+    #col.prop(rd, "use_overwrite")
+    #col.prop(rd, "use_placeholder")
+ 
+    #split.prop(rd, "use_file_extension")
+ 
+    col.label(text = 'Format:')
+    row = col.row()
+    row.template_image_settings(image_settings, color_management=False)
+
+
 
 class VIEW3D_PT_tools_animation_boomsmash(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
-    bl_category = 'Animation'
+    bl_category = 'Playblast'
     bl_context = 'objectmode'
-    bl_label = ' '
-    
+    bl_label = 'Playblast'
+
     def draw_header(self, context):
         DoBTN = self.layout
-        DoBTN.operator('bs.doboom', text = 'BoomSmash', icon = 'RENDER_ANIMATION')
-        DoBTN.prop(context.window_manager.boom_props, 'global_toggle')
+        #DoBTN.operator('bs.doboom', text = 'Playblast', icon = 'RENDER_ANIMATION')
+        #DoBTN.prop(context.window_manager.boom_props, 'global_toggle')
+
         #DoBTN.animation = True
 
     def draw(self, context):
@@ -261,28 +324,28 @@ class VIEW3D_PT_tools_animation_boomsmash(bpy.types.Panel):
 class VIEW3D_PT_tools_pose_animation_boomsmash(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
-    bl_category = 'Tools'
+    bl_category = 'Playblast'
     bl_context = 'posemode'
-    bl_label = ' '
-  
+    bl_label = 'Playblast'
+
     def draw_header(self, context):
         DoBTN = self.layout
-        DoBTN.operator('bs.doboom', text = 'BoomSmash', icon = 'RENDER_ANIMATION')
-        DoBTN.prop(context.window_manager.boom_props, 'global_toggle')
+        #DoBTN.operator('bs.doboom', text = 'Playblast', icon = 'RENDER_ANIMATION')
+        #DoBTN.prop(context.window_manager.boom_props, 'global_toggle')
 
     def draw(self, context):
         layout = self.layout
         draw_boomsmash_panel(context, layout)
-        
-        
+
+
 def register():
     bpy.utils.register_module(__name__)
 
     bpy.types.Scene.boom_props = PointerProperty(
-            type = BoomProps, name = 'BoomSmash Properties', description = '')
+            type = BoomProps, name = 'Playblast Properties', description = '')
 
     bpy.types.WindowManager.boom_props = PointerProperty(
-            type = BoomProps, name = 'BoomSmash Global Properties', description = '')
+            type = BoomProps, name = 'Playblast Global Properties', description = '')
 
 
 def unregister():
@@ -294,6 +357,4 @@ def unregister():
 if __name__ == '__main__':
     register()
     #unregister()
-    print('hecho...')
-
-
+    print('Playblast finish!...')


### PR DESCRIPTION
new features & fixes proposal!

- new name proposal.
- text "boomsmash" changed for "playblast" to consistent with the name.
- select file format added.
- icons changed.
- text for tooltips changed.
- header added.
- save in tmp folder like blender default settings.
- add "_" at final the scene name to separate the frames and name. ej.: (old: namefile_scene0001.avi) (new: namefile_scene_0001.avi).
- add "/" at final the blend file directory to dont join folder name with the file name.